### PR TITLE
Support cursor visibility based on input device type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,7 @@ if test "$ac_cv_enable_static_mb2" = yes; then
 		       dbus-1 dnl
 		       x11 dnl
 		       xcomposite dnl
+		       xi dnl
 		       xfixes dnl
 		       xrandr dnl
 		       xdamage dnl


### PR DESCRIPTION
The logic is: if we receive motion event from a TS device, hide the cursor,
show it otherwise.

Most of the code was borrowed from Cordia h-d

Signed-off-by: Ivaylo Dimitrov <ivo.g.dimitrov.75@gmail.com>