### PR TITLE
hd-app-mgr: Add iio-sensor-proxy backend for rotation.

### DIFF
--- a/src/launcher/hd-app-mgr.h
+++ b/src/launcher/hd-app-mgr.h
@@ -102,7 +102,8 @@ void hd_app_mgr_set_render_manager (GObject *rendermgr);
 gboolean hd_app_mgr_execute (const gchar *exec, GPid *pid, gboolean auto_reap);
 
 gboolean hd_app_mgr_check_show_callui(void);
-void hd_app_mgr_mce_activate_accel_if_needed(gboolean update_portraitness);
+
+void hd_app_mgr_activate_accel_if_needed (gboolean update_portraitness);
 
 extern gboolean conf_enable_ctrl_backspace;
 extern gboolean conf_enable_preset_shift_ctrl;

--- a/src/mb/hd-comp-mgr.c
+++ b/src/mb/hd-comp-mgr.c
@@ -901,7 +901,7 @@ hd_comp_mgr_client_property_changed (XPropertyEvent *event, HdCompMgr *hmgr)
 
   if (STATE_IS_PORTRAIT (hd_render_manager_get_state()))
     { /* Portrait => landscape? */
-      hd_app_mgr_mce_activate_accel_if_needed (FALSE);
+      hd_app_mgr_activate_accel_if_needed (FALSE);
       if (value <= 0 && !hd_comp_mgr_should_be_portrait (hmgr)) {
         PORTRAIT ("UNPORTRAIT");
         hd_render_manager_set_state_unportrait ();
@@ -909,7 +909,8 @@ hd_comp_mgr_client_property_changed (XPropertyEvent *event, HdCompMgr *hmgr)
     }
   else if (STATE_IS_PORTRAIT_CAPABLE (hd_render_manager_get_state()))
     { /* Landscape => portrait? */
-      hd_app_mgr_mce_activate_accel_if_needed (FALSE);
+      
+      hd_app_mgr_activate_accel_if_needed (FALSE);
       if (value != 0 && hd_comp_mgr_should_be_portrait (hmgr))
         hd_render_manager_set_state_portrait ();
     }
@@ -3169,7 +3170,7 @@ hd_comp_mgr_restack (MBWMCompMgr * mgr)
   /* Decide about portraitification in case a blocking window was unmapped. */
   hd_comp_mgr_check_do_not_disturb_flag (HD_COMP_MGR (mgr));
   hd_render_manager_restack ();
-  hd_app_mgr_mce_activate_accel_if_needed (FALSE);
+  hd_app_mgr_activate_accel_if_needed (FALSE);
   hd_comp_mgr_portrait_or_not_portrait (mgr, NULL);
 
   return FALSE;

--- a/src/mb/hd-orientation-lock.c
+++ b/src/mb/hd-orientation-lock.c
@@ -175,7 +175,7 @@ hd_orientation_lock_gconf_value_changed (GConfClient *client,
        * to portrait mode, the priv->portrait variable is set to TRUE. */
       if (STATE_IS_PORTRAIT (hd_render_manager_get_state ()) && !value)
         {
-          hd_app_mgr_mce_activate_accel_if_needed (FALSE);
+          hd_app_mgr_activate_accel_if_needed (FALSE);
           hd_app_mgr_update_orientation ();
         }
   }

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -5,14 +5,16 @@ util_h = 	hd-util.h		\
 		hd-gtk-style.h		\
 		hd-gtk-utils.h		\
 		hd-volume-profile.h		\
-		hd-transition.h
+		hd-transition.h			\
+		iio-dbus.h
 
 util_c = 	hd-util.c		\
 		hd-dbus.c         \
 		hd-gtk-style.c		\
 		hd-gtk-utils.c		\
 		hd-volume-profile.c		\
-		hd-transition.c
+		hd-transition.c			\
+		iio-dbus.c
 
 noinst_LTLIBRARIES = libutil.la
 

--- a/src/util/hd-dbus.c
+++ b/src/util/hd-dbus.c
@@ -203,7 +203,7 @@ hd_dbus_system_bus_signal_handler (DBusConnection *conn,
                     /* possibly go back to the state before tklock */
                     hd_render_manager_set_state (HDRM_STATE_AFTER_TKLOCK);
                   else
-                    hd_app_mgr_mce_activate_accel_if_needed (FALSE);
+                    hd_app_mgr_activate_accel_if_needed (FALSE);
                 }
             }
           else if (!hd_dbus_tklock_on)
@@ -219,7 +219,7 @@ hd_dbus_system_bus_signal_handler (DBusConnection *conn,
               hd_dbus_cunt = call_active
                 && (hd_render_manager_get_state()
                     & (HDRM_STATE_HOME|HDRM_STATE_HOME_PORTRAIT));
-              hd_app_mgr_mce_activate_accel_if_needed (FALSE);
+              hd_app_mgr_activate_accel_if_needed (FALSE);
             }
         }
     }

--- a/src/util/iio-dbus.c
+++ b/src/util/iio-dbus.c
@@ -1,0 +1,80 @@
+#include "iio-dbus.h"
+#include <string.h>
+
+static const char *orientations[] = {
+        "undefined",
+        "normal",
+        "bottom-up",
+        "left-up",
+        "right-up",
+        NULL
+};
+
+int dbus_parse_orientation_property_changed(DBusMessage *m)
+{
+  const char *interface;
+  DBusMessageIter iter, sub;
+
+  if (!dbus_message_iter_init(m, &iter) || dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
+    goto error;
+
+  dbus_message_iter_get_basic(&iter, &interface);
+  
+  if(strcmp(interface, "net.hadess.SensorProxy") != 0)
+    return -1;
+
+  if (!dbus_message_iter_next(&iter) || dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_ARRAY)
+    goto error;
+
+  dbus_message_iter_recurse(&iter, &sub);
+
+  while (dbus_message_iter_get_arg_type(&sub) == DBUS_TYPE_DICT_ENTRY) 
+    {
+      const char *name;
+      DBusMessageIter entry;
+      
+      dbus_message_iter_recurse(&sub, &entry);
+
+      if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING)
+        goto error;
+
+      dbus_message_iter_get_basic(&entry, &name);
+      if(!dbus_message_iter_next(&entry))
+        goto error;
+
+      if (strcmp(name, "AccelerometerOrientation") == 0) 
+        {
+          if (dbus_message_iter_get_arg_type(&entry) == DBUS_TYPE_VARIANT) 
+            {
+              DBusMessageIter variant;
+              const char *orientation;
+              int i = 0;
+              int ret = -1;
+              
+              dbus_message_iter_recurse(&entry, &variant);
+              if (dbus_message_iter_get_arg_type(&variant) != DBUS_TYPE_STRING)
+                return -1;
+              
+              dbus_message_iter_get_basic(&variant, &orientation);
+              
+              while(orientations[i] != NULL)
+                {
+                  if(strcmp(orientations[i], orientation) == 0) 
+                    {
+                      ret = i;
+                      break;
+                    }
+                  ++i;
+                }
+              
+              return ret;
+            }
+          else goto error;
+        }
+
+      dbus_message_iter_next(&sub);
+    }
+
+  error:
+  return -1;
+}

--- a/src/util/iio-dbus.h
+++ b/src/util/iio-dbus.h
@@ -1,0 +1,22 @@
+
+#ifndef __IIO_DBUS_H__
+#define __IIO_DBUS_H__
+
+#include <dbus/dbus.h>
+
+#define IIO_PROXY_PATH "/net/hadess/SensorProxy"
+#define IIO_PROXY_IFACE "net.hadess.SensorProxy"
+#define FDO_PROPERTIES_IFACE "org.freedesktop.DBus.Properties"
+
+typedef enum {
+  ORIENTATION_UNDEFINED = 0,
+  ORIENTATION_NORMAL = 1,
+  ORIENTATION_BOTTOM_UP = 2,
+  ORIENTATION_LEFT_UP = 3,
+  ORIENTATION_RIGHT_UP = 4
+} orientation_enums;
+
+int dbus_parse_orientation_property_changed(DBusMessage *m);
+
+
+#endif


### PR DESCRIPTION
Add  iio-sensor-proxy backend used preferentially to mce. mce is still used when iio-sensor-proxy is not available.

Not tested in a fully functional manner, as portrait mode results in a black screen on my device (droid 4), only tested that the signal is received correctly.