### PR TITLE
hildon-launcher: add environment config

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,6 +4,10 @@ resdir = $(datadir)/hildon-desktop
 res_DATA = \
 	transitions.ini
 
+envconfdir = $(sysconfdir)/hildon-desktop
+envconf_DATA = \
+	environment.conf
+
 sbin_SCRIPTS = hildon-menu-generate
 
 apthookdir = $(sysconfdir)/apt/apt.conf.d

--- a/data/environment.conf
+++ b/data/environment.conf
@@ -1,0 +1,17 @@
+[Hildon]
+# Applications launched by hildon-desktop containing 
+# X-Maemo-Hilon-Integration=true in thair .desktop files
+# and those launched from /usr/share/applications/hildon*
+# will have the key-value pairs in this section appended to
+# thier envvars before launch
+
+HILDON_DESKTOP_HILDONIZE=true
+
+[Generic]
+# All applications launched by hildon-desktop not coverd 
+# by the crieria in the section [Hildon] will have the 
+# key-value pairs in this section appended to thier 
+# envvars before launch
+
+HILDON_DESKTOP_HILDONIZE=false
+

--- a/src/launcher/Makefile.am
+++ b/src/launcher/Makefile.am
@@ -27,6 +27,7 @@ launcher_h = \
 	hd-launcher-grid.h		\
 	hd-launcher-page.h		\
 	hd-launcher-editor.h  \
+	hd-launcher-env.h  \
 	hd-launcher.h
 
 launcher_c = \
@@ -40,6 +41,7 @@ launcher_c = \
 	hd-launcher-grid.c		\
 	hd-launcher-page.c		\
 	hd-launcher-editor.c  \
+	hd-launcher-env.c  \
 	hd-launcher.c
 
 noinst_LTLIBRARIES = liblauncher.la

--- a/src/launcher/hd-app-mgr.c
+++ b/src/launcher/hd-app-mgr.c
@@ -51,6 +51,7 @@
 #include "hd-transition.h"
 #include "hd-wm.h"
 #include "hd-orientation-lock.h"
+#include "hd-launcher-env.h"
 
 #undef  G_LOG_DOMAIN
 #define G_LOG_DOMAIN "hd-app-mgr"
@@ -997,7 +998,8 @@ hd_app_mgr_start (HdRunningApp *app)
       if (exec)
         {
           GPid pid = 0;
-          result = hd_app_mgr_execute (exec, &pid, FALSE);
+          gchar **env = hd_launcher_get_env(hd_launcher_app_get_is_hildon_app (launcher));
+          result = hd_app_mgr_execute (exec, &pid, env, FALSE);
           if (result)
             {
               hd_running_app_set_pid (app, pid);
@@ -1420,7 +1422,7 @@ _hd_app_mgr_child_setup(gpointer user_data)
 }
 
 gboolean
-hd_app_mgr_execute (const gchar *exec, GPid *pid, gboolean auto_reap)
+hd_app_mgr_execute (const gchar *exec, GPid *pid, gchar ** env, gboolean auto_reap)
 {
   gboolean res = FALSE;
   gchar *space = strchr (exec, ' ');
@@ -1452,7 +1454,7 @@ hd_app_mgr_execute (const gchar *exec, GPid *pid, gboolean auto_reap)
   }
 
   res = g_spawn_async (NULL,
-                       argv, NULL,
+                       argv, env,
                        auto_reap ? 0 : G_SPAWN_DO_NOT_REAP_CHILD,
                        _hd_app_mgr_child_setup, NULL,
                        pid,

--- a/src/launcher/hd-app-mgr.h
+++ b/src/launcher/hd-app-mgr.h
@@ -99,7 +99,7 @@ void hd_app_mgr_dump_tree     (void);
 
 void hd_app_mgr_set_render_manager (GObject *rendermgr);
 
-gboolean hd_app_mgr_execute (const gchar *exec, GPid *pid, gboolean auto_reap);
+gboolean hd_app_mgr_execute (const gchar *exec, GPid *pid, gchar **env, gboolean auto_reap);
 
 gboolean hd_app_mgr_check_show_callui(void);
 void hd_app_mgr_mce_activate_accel_if_needed(gboolean update_portraitness);

--- a/src/launcher/hd-launcher-app.c
+++ b/src/launcher/hd-launcher-app.c
@@ -42,6 +42,7 @@
 #define HD_DESKTOP_ENTRY_SWITCHER_ICON  "X-Maemo-Switcher-Icon"
 #define HD_DESKTOP_ENTRY_IGNORE_LOWMEM  "X-Maemo-Ignore-Lowmem"
 #define HD_DESKTOP_ENTRY_IGNORE_LOAD    "X-Maemo-Prestarted-Ignore-Load"
+#define HD_DESKTOP_ENTRY_HILDON_APP     "X-Maemo-Hildon-Integration"
 
 /* DBus names */
 #define OSSO_BUS_ROOT          "com.nokia"
@@ -63,6 +64,7 @@ struct _HdLauncherAppPrivate
   gint priority;
   gboolean ignore_lowmem;
   gboolean ignore_load;
+  gboolean hildon_app;
 };
 
 G_DEFINE_TYPE_WITH_CODE (HdLauncherApp,
@@ -72,6 +74,7 @@ G_DEFINE_TYPE_WITH_CODE (HdLauncherApp,
 
 gboolean hd_launcher_app_parse_keyfile (HdLauncherItem  *item,
                                         GKeyFile        *key_file,
+                                        gboolean        hildon_key_file,
                                         GError          **error);
 
 static void
@@ -220,6 +223,7 @@ static gchar* hd_launcher_strip_exec(gchar *exec)
 gboolean
 hd_launcher_app_parse_keyfile (HdLauncherItem *item,
                                GKeyFile       *key_file,
+                               gboolean hildon_key_file,
                                GError         **error)
 {
   HdLauncherAppPrivate *priv;
@@ -280,6 +284,15 @@ hd_launcher_app_parse_keyfile (HdLauncherItem *item,
                                               HD_DESKTOP_ENTRY_GROUP,
                                               HD_DESKTOP_ENTRY_IGNORE_LOAD,
                                               NULL);
+
+  if (g_key_file_has_key(key_file, HD_DESKTOP_ENTRY_GROUP, HD_DESKTOP_ENTRY_HILDON_APP, NULL)) {
+    priv->hildon_app = g_key_file_get_boolean (key_file,
+                                          HD_DESKTOP_ENTRY_GROUP,
+                                          HD_DESKTOP_ENTRY_HILDON_APP,
+                                          NULL);
+  } else {
+    priv->hildon_app = hildon_key_file;
+  }
 
   return TRUE;
 }
@@ -382,4 +395,11 @@ gboolean hd_launcher_app_match_window (HdLauncherApp *app,
     return TRUE;
 
   return FALSE;
+}
+
+gboolean
+hd_launcher_app_get_is_hildon_app (HdLauncherApp *app)
+{
+  HdLauncherAppPrivate *priv = HD_LAUNCHER_APP_GET_PRIVATE (app);
+  return priv->hildon_app;
 }

--- a/src/launcher/hd-launcher-app.h
+++ b/src/launcher/hd-launcher-app.h
@@ -84,6 +84,8 @@ gboolean hd_launcher_app_match_window (HdLauncherApp *app,
                                        const gchar *res_name,
                                        const gchar *res_class);
 
+gboolean hd_launcher_app_get_is_hildon_app (HdLauncherApp *app);
+
 G_END_DECLS
 
 #endif /* __HD_LAUNCHER_APP_H__ */

--- a/src/launcher/hd-launcher-cat.c
+++ b/src/launcher/hd-launcher-cat.c
@@ -37,7 +37,7 @@ hd_launcher_cat_finalize (GObject *gobject)
 
 static gboolean
 hd_launcher_cat_parse_keyfile (HdLauncherItem *item,
-                               GKeyFile *key_file,
+                               GKeyFile *key_file, gboolean hildon_app,
                                GError **error)
 {
   return TRUE;

--- a/src/launcher/hd-launcher-env.c
+++ b/src/launcher/hd-launcher-env.c
@@ -1,0 +1,69 @@
+#include <glib.h>
+#include <glib/gprintf.h>
+#include <stdio.h>
+#include "hd-launcher-env.h"
+
+#define ENV_INI             "/etc/hildon-desktop/environment.conf"
+#define ENV_GENERIC_GROUP     "Generic"
+#define ENV_HILDON_GROUP      "Hildon"
+
+static char **env_generic = NULL;
+static char **env_hildon = NULL;
+
+static void hd_launcher_env_load(void)
+{
+  GKeyFile *keyFile = g_key_file_new();
+  
+  env_generic = g_get_environ();
+  env_hildon = g_get_environ();
+  
+  if (!g_key_file_load_from_file(keyFile, ENV_INI, G_KEY_FILE_NONE, NULL)) {
+    g_key_file_free(keyFile);
+    return;
+  }
+  
+  gchar **genericKeys = g_key_file_get_keys(keyFile, ENV_GENERIC_GROUP, NULL, NULL);
+  if (genericKeys) {
+    for (int i = 0; genericKeys[i] != NULL; ++i) {
+      char *var = g_key_file_get_string(keyFile, ENV_GENERIC_GROUP, genericKeys[i], NULL);
+      if(var) {
+        env_generic = g_environ_setenv(env_generic, genericKeys[i], var, TRUE);
+        g_free(var);
+      }
+    }
+    g_strfreev(genericKeys);
+  }
+  
+  gchar **hildonKeys = g_key_file_get_keys(keyFile, ENV_HILDON_GROUP, NULL, NULL);
+  if (hildonKeys) {
+    for (int i = 0; hildonKeys[i] != NULL; ++i) {
+      char *var = g_key_file_get_string(keyFile, ENV_HILDON_GROUP, hildonKeys[i], NULL);
+      if(var) {
+        env_hildon = g_environ_setenv(env_hildon, hildonKeys[i], var, TRUE);
+        g_free(var);
+      }
+    }
+    g_strfreev(hildonKeys);
+  }
+  
+  g_key_file_free(keyFile);
+}
+
+char **hd_launcher_get_env(gboolean hildonize)
+{
+  if (!env_generic || !env_hildon)
+    hd_launcher_env_load();
+  
+  if (hildonize)
+    return env_hildon;
+  else 
+    return env_generic;
+}
+
+void hd_launcher_env_free(void) 
+{
+  if (env_generic) 
+    g_strfreev(env_generic);
+  if (env_hildon) 
+    g_strfreev(env_hildon);
+}

--- a/src/launcher/hd-launcher-env.h
+++ b/src/launcher/hd-launcher-env.h
@@ -1,0 +1,9 @@
+#ifndef __HD_LAUNCHER_ENV_H__
+#define __HD_LAUNCHER_ENV_H__
+
+#include <glib.h>
+
+char **hd_launcher_get_env(gboolean hildonize);
+void hd_launcher_env_free(void);
+
+#endif

--- a/src/launcher/hd-launcher-item.c
+++ b/src/launcher/hd-launcher-item.c
@@ -102,6 +102,7 @@ G_DEFINE_ABSTRACT_TYPE_WITH_CODE (HdLauncherItem,
 /* Forward declarations */
 gboolean hd_launcher_item_parse_keyfile (HdLauncherItem *item,
                                          GKeyFile *key_file,
+                                         gboolean hildon_key_file,
                                          GError **error);
 
 static void
@@ -307,6 +308,7 @@ hd_launcher_item_get_category (HdLauncherItem *item)
 gboolean
 hd_launcher_item_parse_keyfile (HdLauncherItem *item,
                                 GKeyFile *key_file,
+                                gboolean hildon_key_file,
                                 GError **error)
 {
   HdLauncherItemPrivate *priv = HD_LAUNCHER_ITEM_GET_PRIVATE (item);
@@ -315,6 +317,8 @@ hd_launcher_item_parse_keyfile (HdLauncherItem *item,
                                       HD_DESKTOP_ENTRY_GROUP,
                                       HD_DESKTOP_ENTRY_NAME,
                                       NULL);
+  (void)hildon_key_file;
+  
   if (!priv->name)
     {
       g_free (priv->name);
@@ -344,6 +348,7 @@ HdLauncherItem *
 hd_launcher_item_new_from_keyfile (const gchar *id,
                                    const gchar *category,
                                    GKeyFile *key_file,
+                                   gboolean hildon_key_file,
                                    GError **error)
 {
   HdLauncherItem *result;
@@ -410,14 +415,14 @@ hd_launcher_item_new_from_keyfile (const gchar *id,
   result->priv->item_type = type_value->value;
   result->priv->id = g_strdup (id);
   result->priv->id_quark = g_quark_from_string (result->priv->id);
-  if (!hd_launcher_item_parse_keyfile (result, key_file, error))
+  if (!hd_launcher_item_parse_keyfile (result, key_file, hildon_key_file, error))
     {
       g_object_unref (result);
       return NULL;
     }
 
   if (!(HD_LAUNCHER_ITEM_GET_CLASS (result))->parse_key_file
-            (result, key_file, error))
+            (result, key_file, hildon_key_file, error))
     {
       g_object_unref (result);
       return NULL;

--- a/src/launcher/hd-launcher-item.h
+++ b/src/launcher/hd-launcher-item.h
@@ -71,6 +71,7 @@ struct _HdLauncherItemClass
   /* Virtual methods */
   gboolean (* parse_key_file) (HdLauncherItem *item,
                                GKeyFile *key_file,
+                               gboolean hildon_key_file,
                                GError **error);
 };
 
@@ -80,6 +81,7 @@ GType              hd_launcher_item_get_type      (void) G_GNUC_CONST;
 HdLauncherItem *   hd_launcher_item_new_from_keyfile (const gchar *id,
                                                       const gchar *category,
                                                       GKeyFile *key_file,
+                                                      gboolean hildon_key_file,
                                                       GError   **error);
 const gchar *      hd_launcher_item_get_id           (HdLauncherItem *item);
 GQuark             hd_launcher_item_get_id_quark     (HdLauncherItem *item);

--- a/src/launcher/hd-launcher-tree.c
+++ b/src/launcher/hd-launcher-tree.c
@@ -237,7 +237,7 @@ walk_thread_func (gpointer user_data)
       if (key_file) {
         item = hd_launcher_item_new_from_keyfile (id,
                   gmenu_tree_directory_get_menu_id (data->root),
-                  key_file, NULL);
+                  key_file, strstr(key_file_path, "hildon") != NULL, NULL);
 	g_key_file_free (key_file);
       }
       if (item)

--- a/src/main.c
+++ b/src/main.c
@@ -339,7 +339,7 @@ key_binding_func (MBWindowManager   *wm,
     case KEY_ACTION_XTERMINAL:
       {
         GPid pid;
-        if (hd_app_mgr_execute ("/usr/bin/osso-xterm", &pid, TRUE))
+        if (hd_app_mgr_execute ("/usr/bin/osso-xterm", &pid, NULL, TRUE))
           g_spawn_close_pid (pid);
         break;
       }


### PR DESCRIPTION
add enviorment config that changes the eviroment used to launch applications based on a new X-Maemo-Hilon-Integration .desktop parameter and the .desktop file's location. The envvars are set in accordance to /etc/hildon-desktop/environment.conf