### PR TITLE
Several Fixups

### DIFF
--- a/src/launcher/hd-launcher-app.c
+++ b/src/launcher/hd-launcher-app.c
@@ -29,6 +29,7 @@
 
 #include "hildon-desktop.h"
 #include "hd-launcher-app.h"
+#include "hd-util.h"
 
 #include <string.h>
 
@@ -252,21 +253,12 @@ hd_launcher_app_parse_keyfile (HdLauncherItem *item,
                                              NULL);
   if ((priv->exec) && terminal) {
       gchar *old_exec = priv->exec;
-      gchar *term = NULL;
-      const gchar *term_env = g_getenv("TERMINAL");
+      gchar *term = hd_util_get_default_terminal();
 
-      if (term_env)
-        term = g_find_program_in_path(g_path_get_basename(term_env));
-      else
-        term = g_find_program_in_path(g_path_get_basename("x-terminal-emulator"));
-
-      if (term) {
-        priv->exec = g_strdup_printf("%s '%s'", term, old_exec);
-        g_free(term);
-      } else
-        priv->exec = g_strdup_printf("%s '%s'", "osso-xterm", old_exec);
+      priv->exec = g_strdup_printf("%s '%s'", term, old_exec);
 
       g_free(old_exec);
+      g_free(term);
   }
 
   priv->loading_image = g_key_file_get_string (key_file,

--- a/src/util/hd-shortcuts.c
+++ b/src/util/hd-shortcuts.c
@@ -240,10 +240,17 @@ static void key_binding_func(MBWindowManager * wm, MBWMKeyBinding * binding, voi
 
 static void hd_shortcuts_add(MBWindowManager * wm, GKeyFile * file, gchar * key, unsigned int action)
 {
-	gchar *keystr = g_key_file_get_string(file, "Shortcuts", key, NULL);
+	gsize len;
+	gsize i;
+	gchar **keystrlist = g_key_file_get_string_list(file, "Shortcuts", key, &len, NULL);
 	
-	if (keystr)
-		mb_wm_keys_binding_add_with_spec(wm, keystr, key_binding_func, NULL, GUINT_TO_POINTER(action));
+	if(!keystrlist)
+		return;
+
+	for (i = 0; i < len; ++i)
+		mb_wm_keys_binding_add_with_spec(wm, keystrlist[i], key_binding_func, NULL, GUINT_TO_POINTER(action));
+
+	g_strfreev(keystrlist);
 }
 
 void hd_shortcuts_setup(MBWindowManager * wm)

--- a/src/util/hd-shortcuts.c
+++ b/src/util/hd-shortcuts.c
@@ -24,6 +24,7 @@
 #include "hd-transition.h"
 #include "hd-orientation-lock.h"
 #include "hd-home.h"
+#include "hd-util.h"
 
 #define SHORTCUTS_INI "/usr/share/hildon-desktop/shortcuts.ini"
 
@@ -227,8 +228,11 @@ static void key_binding_func(MBWindowManager * wm, MBWMKeyBinding * binding, voi
 	case KEY_ACTION_XTERMINAL:
 		{
 			GPid pid;
-			if (hd_app_mgr_execute("/usr/bin/osso-xterm", &pid, TRUE))
+			gchar *term = hd_util_get_default_terminal();
+
+			if (hd_app_mgr_execute(term, &pid, TRUE))
 				g_spawn_close_pid(pid);
+			g_free(term);
 			break;
 		}
 

--- a/src/util/hd-util.c
+++ b/src/util/hd-util.c
@@ -3,7 +3,6 @@
 #include <matchbox/core/mb-wm.h>
 #include <clutter/x11/clutter-x11.h>
 #include <cogl/cogl.h>
-#include <unistd.h>
 
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
@@ -352,11 +351,6 @@ hd_util_change_screen_orientation_real (MBWindowManager *wm,
   int width, height, width_mm, height_mm;
   unsigned long one = 1;
   gboolean rv = FALSE;
-
-  /* TODO: remove this hack that avoids bug in omap ddx?
-   * remove #include <unistd.h> while at it.
-   */
-  usleep(100000);
 
   if (!randr_supported(wm))
     {

--- a/src/util/hd-util.c
+++ b/src/util/hd-util.c
@@ -965,3 +965,19 @@ hd_util_display_height()
 
   return height;
 }
+
+gchar *hd_util_get_default_terminal(void)
+{
+  gchar *term = NULL;
+  const gchar *term_env = g_getenv("TERMINAL");
+
+  if (term_env)
+    term = g_find_program_in_path(g_path_get_basename(term_env));
+  else
+    term = g_find_program_in_path(g_path_get_basename("x-terminal-emulator"));
+
+  if (!term)
+    term = g_strdup("osso-xterm");
+
+  return term;
+}

--- a/src/util/hd-util.h
+++ b/src/util/hd-util.h
@@ -56,4 +56,6 @@ guint hd_util_display_width(void);
 /* Display height, accounting for initial rotation */
 guint hd_util_display_height(void);
 
+gchar *hd_util_get_default_terminal(void);
+
 #endif


### PR DESCRIPTION
This:
- allows mulltiple shortcuts to be added to a single action
  - finally everyone can stop bugging me about ctrl-backspace and mapphone home key not working at the same time
- changes the terminal launch action to  launch the same terminal as the terminal=true .desktop file key instead of hardcodeing osso-xterm
- removes a old workaround around a ddk1.9 bug we dont have in ddk1.17 anymore